### PR TITLE
Fix board items dissapearing

### DIFF
--- a/INTE-Project/src/main/java/com/Grupp25/app/board/Board.java
+++ b/INTE-Project/src/main/java/com/Grupp25/app/board/Board.java
@@ -100,9 +100,9 @@ public class Board extends JFrame implements KeyListener {
 
     public void moveItem(BoardItem item, Direction direction) {
         Position p = getItemPosition(item);
-        p.setBoardItem(null);
-        Position nextPosition = getNextPosition(direction, p);
-        if (nextPosition != null) {
+        Position nextPosition = getNextPosition(direction, p);            
+        if (nextPosition != null && nextPosition.getBoardItem() == null) {
+            p.setBoardItem(null);
             nextPosition.setBoardItem(item);
             addGraphics(nextPosition, item.getGraphics(), 4);
             return;


### PR DESCRIPTION
Check that the position is not occupied and that it exists before removing and adding board item.